### PR TITLE
Add AT_REMOVEDIR_DATALESS and AT_FDONLY flags and EINVAL error for *at functions

### DIFF
--- a/darling/src/libsystem_kernel/emulation/linux/common_at.c
+++ b/darling/src/libsystem_kernel/emulation/linux/common_at.c
@@ -7,10 +7,21 @@ int atflags_bsd_to_linux(int flags)
 
 	if (flags & BSD_AT_SYMLINK_NOFOLLOW)
 		linux_flags |= LINUX_AT_SYMLINK_NOFOLLOW;
-	if (flags & BSD_AT_REMOVEDIR)
+	if (flags & BSD_AT_REMOVEDIR || flags & BSD_AT_REMOVEDIR_DATALESS)
 		linux_flags |= LINUX_AT_REMOVEDIR;
 	if (flags & BSD_AT_SYMLINK_FOLLOW)
 		linux_flags |= LINUX_AT_SYMLINK_FOLLOW;
+	if (flags & BSD_AT_FDONLY)
+		linux_flags |= LINUX_AT_EMPTY_PATH;
+	flags &= ~BSD_AT_SYMLINK_NOFOLLOW;
+	flags &= ~BSD_AT_REMOVEDIR;
+	flags &= ~BSD_AT_REMOVEDIR_DATALESS;
+	flags &= ~BSD_AT_SYMLINK_FOLLOW;
+	flags &= ~BSD_AT_EACCESS;
+	flags &= ~BSD_AT_REALDEV;
+	flags &= ~BSD_AT_FDONLY;
+	if (flags != 0)
+		linux_flags = LINUX_AT_INVALID;
 
 	return linux_flags;
 }

--- a/darling/src/libsystem_kernel/emulation/linux/common_at.h
+++ b/darling/src/libsystem_kernel/emulation/linux/common_at.h
@@ -3,15 +3,21 @@
 
 // Common declarations for the *at family of system calls
 
+#define LINUX_AT_INVALID 		0x1
 #define LINUX_AT_FDCWD	-100
 #define LINUX_AT_SYMLINK_NOFOLLOW	0x100
 #define LINUX_AT_REMOVEDIR			0x200
 #define LINUX_AT_SYMLINK_FOLLOW		0x400
+#define LINUX_AT_EMPTY_PATH		0x1000
 
 #define BSD_AT_FDCWD	-2
 #define BSD_AT_SYMLINK_NOFOLLOW		0x20
 #define BSD_AT_REMOVEDIR			0x80
 #define BSD_AT_SYMLINK_FOLLOW		0x40
+#define BSD_AT_EACCESS			0x10
+#define BSD_AT_REMOVEDIR_DATALESS		0x100
+#define BSD_AT_REALDEV 			0x200
+#define BSD_AT_FDONLY			0x400
 
 int atflags_bsd_to_linux(int flags);
 

--- a/darling/src/libsystem_kernel/emulation/linux/stat/fstatat.c
+++ b/darling/src/libsystem_kernel/emulation/linux/stat/fstatat.c
@@ -29,6 +29,8 @@ long sys_fstatat(int fd, const char* path, struct stat* stat, int flag)
 		return errno_linux_to_bsd(ret);
 
 	linux_flags = atflags_bsd_to_linux(flag);
+	if (linux_flags == LINUX_AT_INVALID)
+		return -EINVAL;
 
 #ifdef __NR_newfstatat
 	ret = LINUX_SYSCALL(__NR_newfstatat, vc.dfd, vc.path, &lstat, linux_flags);
@@ -63,6 +65,8 @@ long sys_fstatat64(int fd, const char* path, struct stat64* stat, int flag)
 		return errno_linux_to_bsd(ret);
 
 	linux_flags = atflags_bsd_to_linux(flag);
+	if (linux_flags == LINUX_AT_INVALID)
+		return -EINVAL;
 
 #ifdef __NR_newfstatat
 	ret = LINUX_SYSCALL(__NR_newfstatat, vc.dfd, vc.path, &lstat, linux_flags);

--- a/darling/src/libsystem_kernel/emulation/linux/unistd/faccessat.c
+++ b/darling/src/libsystem_kernel/emulation/linux/unistd/faccessat.c
@@ -5,6 +5,7 @@
 #include "../common_at.h"
 #include "../vchroot_expand.h"
 #include <mach/lkm.h>
+#include <sys/errno.h>
 
 extern char* strcpy(char* dst, const char* src);
 
@@ -13,6 +14,7 @@ long sys_faccessat(int fd, const char* filename, int amode, int flag)
 	int ret;
 
 	struct vchroot_expand_args vc;
+	int linux_flags;
 
 	vc.flags = (flag & BSD_AT_SYMLINK_NOFOLLOW) ? 0 : VCHROOT_FOLLOW;
 	vc.dfd = atfd(fd);
@@ -23,7 +25,11 @@ long sys_faccessat(int fd, const char* filename, int amode, int flag)
 	if (ret < 0)
 		return errno_linux_to_bsd(ret);
 
-	ret = LINUX_SYSCALL(__NR_faccessat, vc.dfd, vc.path, amode, atflags_bsd_to_linux(flag));
+	linux_flags = atflags_bsd_to_linux(flag);
+	if (linux_flags == LINUX_AT_INVALID)
+		return -EINVAL;
+
+	ret = LINUX_SYSCALL(__NR_faccessat, vc.dfd, vc.path, amode, linux_flags);
 
 	if (ret < 0)
 		ret = errno_linux_to_bsd(ret);

--- a/darling/src/libsystem_kernel/emulation/linux/unistd/fchownat.c
+++ b/darling/src/libsystem_kernel/emulation/linux/unistd/fchownat.c
@@ -5,6 +5,7 @@
 #include "../common_at.h"
 #include "../vchroot_expand.h"
 #include <mach/lkm.h>
+#include <sys/errno.h>
 
 extern char* strcpy(char* dst, const char* src);
 
@@ -13,6 +14,7 @@ long sys_fchownat(int fd, const char* path, int uid, int gid, int flag)
 #if 0
 	int ret;
 	struct vchroot_expand_args vc;
+	int linux_flags;
 
 	vc.flags = VCHROOT_FOLLOW;
 	vc.dfd = atfd(fd);
@@ -23,7 +25,11 @@ long sys_fchownat(int fd, const char* path, int uid, int gid, int flag)
 	if (ret < 0)
 		return errno_linux_to_bsd(ret);
 
-	ret = LINUX_SYSCALL(__NR_fchownat, vc.dfd, vc.path, uid, gid, atflags_bsd_to_linux(flag));
+	linux_flags = atflags_bsd_to_linux(flag);
+	if (linux_flags == LINUX_AT_INVALID)
+		return -EINVAL;
+
+	ret = LINUX_SYSCALL(__NR_fchownat, vc.dfd, vc.path, uid, gid, linux_flags);
 
 	if (ret < 0)
 		ret = errno_linux_to_bsd(ret);

--- a/darling/src/libsystem_kernel/emulation/linux/unistd/linkat.c
+++ b/darling/src/libsystem_kernel/emulation/linux/unistd/linkat.c
@@ -6,6 +6,7 @@
 #include "../common_at.h"
 #include "../vchroot_expand.h"
 #include <mach/lkm.h>
+#include <sys/errno.h>
 
 extern char* strcpy(char* dst, const char* src);
 
@@ -13,6 +14,7 @@ long sys_linkat(int fd, const char* path, int fdlink, const char* link, int flag
 {
 	int ret;
 	struct vchroot_expand_args vc, vc2;
+	int linux_flags;
 
 	vc.flags = (flag & BSD_AT_SYMLINK_FOLLOW) ? VCHROOT_FOLLOW : 0;
 	vc.dfd = atfd(fd);
@@ -32,7 +34,11 @@ long sys_linkat(int fd, const char* path, int fdlink, const char* link, int flag
 	if (ret < 0)
 		return errno_linux_to_bsd(ret);
 
-	ret = LINUX_SYSCALL(__NR_linkat, vc.dfd, vc.path, vc2.dfd, vc2.path, atflags_bsd_to_linux(flag));
+	linux_flags = atflags_bsd_to_linux(flag);
+	if (linux_flags == LINUX_AT_INVALID)
+		return -EINVAL;
+
+	ret = LINUX_SYSCALL(__NR_linkat, vc.dfd, vc.path, vc2.dfd, vc2.path, linux_flags);
 	if (ret < 0)
 		ret = errno_linux_to_bsd(ret);
 

--- a/darling/src/libsystem_kernel/emulation/linux/unistd/unlinkat.c
+++ b/darling/src/libsystem_kernel/emulation/linux/unistd/unlinkat.c
@@ -5,6 +5,7 @@
 #include "../common_at.h"
 #include "../vchroot_expand.h"
 #include <mach/lkm.h>
+#include <sys/errno.h>
 
 extern char* strcpy(char* dst, const char* src);
 
@@ -12,6 +13,7 @@ long sys_unlinkat(int fd, const char* path, int flag)
 {
 	int ret;
 	struct vchroot_expand_args vc;
+	int linux_flags;
 
 	vc.flags = 0;
 	vc.dfd = atfd(fd);
@@ -22,7 +24,11 @@ long sys_unlinkat(int fd, const char* path, int flag)
 	if (ret < 0)
 		return errno_linux_to_bsd(ret);
 
-	ret = LINUX_SYSCALL(__NR_unlinkat, vc.dfd, vc.path, atflags_bsd_to_linux(flag));
+	linux_flags = atflags_bsd_to_linux(flag);
+	if (linux_flags == LINUX_AT_INVALID)
+		return -EINVAL;
+
+	ret = LINUX_SYSCALL(__NR_unlinkat, vc.dfd, vc.path, linux_flags);
 	if (ret < 0)
 		ret = errno_linux_to_bsd(ret);
 


### PR DESCRIPTION
Implemented AT_REMOVEDIR_DATALESS and AT_FDONLY flags.
Implemented the error EINVAL for invalid flags that are passed to *at functions.
Added AT_EACCESS and AT_REALDEV flags but are currently ignored.
Fixes [darlinghq/darling#1383](https://github.com/darlinghq/darling/issues/1383)