### PR TITLE
Fix And Rework Assembly Code For "pthread_entry_point_wrapper" And "wqueue_entry_point_wrapper"

### DIFF
--- a/darling/src/libsystem_kernel/emulation/linux/CMakeLists.txt
+++ b/darling/src/libsystem_kernel/emulation/linux/CMakeLists.txt
@@ -5,7 +5,7 @@ add_subdirectory(mach)
 cmake_policy(SET CMP0005 NEW)
 enable_language(ASM)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -fvisibility=hidden -fPIC -fno-builtin -ggdb -Wno-int-conversion -Wno-compare-distinct-pointer-types")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -fvisibility=hidden -fPIC -fno-builtin -ggdb -Wno-int-conversion -Wno-compare-distinct-pointer-types")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -nostdlib")
 
 add_definitions(-DBSDTHREAD_WRAP_LINUX_PTHREAD

--- a/darling/src/libsystem_kernel/emulation/linux/bsdthread/bsdthread_register.c
+++ b/darling/src/libsystem_kernel/emulation/linux/bsdthread/bsdthread_register.c
@@ -116,14 +116,19 @@ void pthread_entry_point_wrapper(void* self, int thread_port, void* funptr,
 	__builtin_unreachable();
 }
 
-// Before you make any changes to the assembly code, I strongly recommend looking at the `_start_wqthread`
-// code. `_start_wqthread` does not follow the usual calling conventions you would expect. You can find the
-// source in `libpthread/src/pthread_asm.S`.
 void wqueue_entry_point_wrapper(void* self, int thread_port, void* stackaddr,
 		void* item, int reuse, int nevents)
 {
 	sigexc_thread_setup();
+	wqueue_entry_point_asm_jump(self, thread_port, stackaddr, item, reuse, nevents);
+}
 
+// Before you make any changes to the assembly code, I strongly recommend looking at the `_start_wqthread`
+// code. `_start_wqthread` does not follow the usual calling conventions you would expect. You can find the
+// source in `libpthread/src/pthread_asm.S`.
+void wqueue_entry_point_asm_jump(void* self, int thread_port, void* stackaddr,
+		void* item, int reuse, int nevents) {
+	
 	// No additional function calls should occur beyond this point. Otherwise, we will risk our
 	// registers being call-clobbered. I recommend reading the following doc for more details:
 	// https://gcc.gnu.org/onlinedocs/gcc/Local-Register-Variables.html

--- a/darling/src/libsystem_kernel/emulation/linux/bsdthread/bsdthread_register.h
+++ b/darling/src/libsystem_kernel/emulation/linux/bsdthread/bsdthread_register.h
@@ -18,6 +18,8 @@ void pthread_entry_point_wrapper(void* self, int thread_port, void* funptr,
 		void* funarg, unsigned long stacksize, unsigned int flags);
 void wqueue_entry_point_wrapper(void* self, int thread_port, void* stackaddr,
 		void* item, int reuse, int nevents);
+void wqueue_entry_point_asm_jump(void* self, int thread_port, void* stackaddr,
+		void* item, int reuse, int nevents);
 
 #endif
 


### PR DESCRIPTION
In `libpthread/src/pthread_asm.S`, `_thread_start` and `_start_wqthread` are designed with the assumption that the code would run from kernel space. This means that the following functions don't follow all of the standard calling conventions that are expected for x86_64 or i386.