### PR TITLE
ulock_wait: Fix timeout calculation

### DIFF
--- a/darling/src/libsystem_kernel/emulation/src/xnu_syscall/bsd/impl/psynch/ulock_wait.c
+++ b/darling/src/libsystem_kernel/emulation/src/xnu_syscall/bsd/impl/psynch/ulock_wait.c
@@ -29,7 +29,7 @@ long sys_ulock_wait(uint32_t operation, void* addr, uint64_t value, uint32_t tim
 
 	if (timeout > 0)
 	{
-		ts.tv_sec = timeout / 1000*1000;
+		ts.tv_sec = timeout / (1000*1000);
 		ts.tv_nsec = (timeout % (1000*1000)) * 1000;
 	}
 


### PR DESCRIPTION
- Fix the order of operations to calculate tv_sec: Previously it would just divide and then multiply microseconds by 1000 again, instead of dividing by (1000 * 1000)
- Should fix https://github.com/darlinghq/darling/issues/1604