### PR TITLE
Implement BSD syscall 520: terminate with payload

### DIFF
--- a/darling/src/libsystem_kernel/emulation/CMakeLists.txt
+++ b/darling/src/libsystem_kernel/emulation/CMakeLists.txt
@@ -140,6 +140,7 @@ set(xnu_syscall_bsd_sources
 	src/xnu_syscall/bsd/impl/kqueue/kevent64.c
 	src/xnu_syscall/bsd/impl/kqueue/kevent_qos.c
 	src/xnu_syscall/bsd/impl/kqueue/kqueue.c
+	src/xnu_syscall/bsd/impl/misc/terminate_with_payload.c
 	src/xnu_syscall/bsd/impl/misc/abort_with_payload.c
 	src/xnu_syscall/bsd/impl/misc/clonefile.c
 	src/xnu_syscall/bsd/impl/misc/csops.c
@@ -378,4 +379,3 @@ add_dependencies(emulation_dyld rtsig_h generate_dserver_rpc_wrappers)
 
 make_fat(emulation)
 make_fat(emulation_dyld)
-

--- a/darling/src/libsystem_kernel/emulation/include/xnu_syscall/bsd/impl/misc/terminate_with_payload.h
+++ b/darling/src/libsystem_kernel/emulation/include/xnu_syscall/bsd/impl/misc/terminate_with_payload.h
@@ -1,0 +1,6 @@
+#ifndef LINUX_TERMINATE_WITH_PAYLOAD_H
+#define LINUX_TERMINATE_WITH_PAYLOAD_H
+
+long sys_terminate_with_payload(unsigned int reason_namespace, unsigned long long reason_code, void *payload, unsigned int payload_size, const char *reason_string, unsigned long long reason_flags);
+
+#endif // LINUX_TERMINATE_WITH_PAYLOAD_H

--- a/darling/src/libsystem_kernel/emulation/src/xnu_syscall/bsd/bsd_syscall_table.c
+++ b/darling/src/libsystem_kernel/emulation/src/xnu_syscall/bsd/bsd_syscall_table.c
@@ -31,6 +31,7 @@
 #include <darling/emulation/xnu_syscall/bsd/impl/kqueue/kevent64.h>
 #include <darling/emulation/xnu_syscall/bsd/impl/kqueue/kevent_qos.h>
 #include <darling/emulation/xnu_syscall/bsd/impl/kqueue/kqueue.h>
+#include <darling/emulation/xnu_syscall/bsd/impl/misc/terminate_with_payload.h>
 #include <darling/emulation/xnu_syscall/bsd/impl/misc/abort_with_payload.h>
 #include <darling/emulation/xnu_syscall/bsd/impl/misc/clonefile.h>
 #include <darling/emulation/xnu_syscall/bsd/impl/misc/csops.h>
@@ -484,6 +485,7 @@ void* __bsd_syscall_table[600] = {
 	[515] = sys_ulock_wait,
 	[516] = sys_ulock_wake,
 	[517] = sys_fclonefileat,
+	[520] = sys_terminate_with_payload,
 	[521] = sys_abort_with_payload,
 	[524] = sys_setattrlistat,
 };

--- a/darling/src/libsystem_kernel/emulation/src/xnu_syscall/bsd/impl/misc/terminate_with_payload.c
+++ b/darling/src/libsystem_kernel/emulation/src/xnu_syscall/bsd/impl/misc/terminate_with_payload.c
@@ -1,0 +1,13 @@
+#include <darling/emulation/xnu_syscall/bsd/impl/misc/terminate_with_payload.h>
+
+#include <sys/signal.h>
+
+#include <darling/emulation/xnu_syscall/bsd/impl/signal/kill.h>
+#include <darling/emulation/common/simple.h>
+
+long sys_terminate_with_payload(unsigned int reason_namespace, unsigned long long reason_code, void *payload, unsigned int payload_size, const char *reason_string, unsigned long long reason_flags)
+{
+	__simple_printf("terminate_with_payload: reason: %s; code: %lu\n", reason_string, reason_code);
+	sys_kill(0, SIGTERM, 1);
+	return 0;
+}


### PR DESCRIPTION
I'm not sure how to test this, as I can't figure out how to compile just darling-xnu without the rest of darling. Also, I'm not sure if there are unit tests?